### PR TITLE
Make README more accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Name of the status property that will receive a new tag based on the triggered
 action
 
-### `url-property-name`
+### `github-url-property-name`
 
 Name of the url property that will receive the url of the PR
 
@@ -36,7 +36,7 @@ with:
     - required-suffix: ')'
     - required-prefix: '[Notion ticket]('
     - status-property-name: 'Status'
-    - url-property-name: 'Github URL'
+    - github-url-property-name: 'Github URL'
     - opened: 'In progresss'
     - edited: 'In progress'
     - closed: 'Done'


### PR DESCRIPTION
The listed workflow property to reference the Notion url in the README didn't match up with what is seen in source code.

As we pulled in an updated version, we thought the name of the property changed, but [as found in the source code](https://github.com/ThomasF34/update-notion/pull/4/files#diff-725af26583c062fde4165f6c791c0597c6a5b2157304121b17c03487c91443a8R12), the property name is actually `github-url-property-name`.